### PR TITLE
Bump LTS to 10.2 and fix bug in text quasi quoting

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-7.8
+resolver: lts-10.2
 
 packages:
 - '.'


### PR DESCRIPTION
I noticed after upgrading to lts-10.2 in our own stack project that we were getting compile errors when using `qt`. It turns out it wasn't just `qt` but any quasi quoters that weren't producing `String`.

I was able to reproduce the problem by setting the lts in the `stack.yaml` in this repo to 10.2 and then running the following in `stack ghci`:
```haskell
> let foo = T.pack "bar" :: T.Text
> :set -XQuasiQuotes
> [qt|${foo}|]

<interactive>:8:5: error:
    • Couldn't match expected type ‘T.Text’ with actual type ‘[Char]’
    • In the second argument of ‘(Data.Monoid.<>)’, namely
        ‘(((Data.Monoid.<>) []) "")’
      In the second argument of ‘(Data.Monoid.<>)’, namely
        ‘(((Data.Monoid.<>) (toText foo)) (((Data.Monoid.<>) []) ""))’
      In the expression:
        (((Data.Monoid.<>) [])
           (((Data.Monoid.<>) (toText foo)) (((Data.Monoid.<>) []) "")))
```

Im not sure of the exact changes toTemplate Haskell in the new LTS/GHC release, but it appears that it is no longer coercing strings to text automatically inside the the template haskell quoting in [QM.hs](https://github.com/tolysz/rawstring-qm/compare/master...Simspace:lts-10.2-fix?expand=1#diff-d44e1d14813c3bd873145f0d64eec9df).

The solution was to use `pack`/`fromString` inside the quoting and `mempty` instead of a string literal for the base case.
  
  
  